### PR TITLE
avoid deepcopy

### DIFF
--- a/src/MolecularEvolution.jl
+++ b/src/MolecularEvolution.jl
@@ -22,6 +22,13 @@ abstract type Partition end
 abstract type DiscretePartition <: Partition end
 abstract type ContinuousPartition <: Partition end
 
+function Base.copy(p::P) where P <: Partition
+    return P(ntuple(i -> copy(getfield(p, i)), fieldcount(P))...)
+end
+
+# not-so-deep copy
+copymessage(msg::Vector{<:Partition}) = [copy(x) for x in msg]
+
 abstract type BranchModel end
 abstract type DiscreteStateModel <: BranchModel end
 abstract type SimulationModel <: BranchModel end #Simulation models typically can't propogate uncertainty, and aren't used for inference

--- a/src/core/nodes/FelNode.jl
+++ b/src/core/nodes/FelNode.jl
@@ -62,10 +62,10 @@ end
 function internal_message_init!(tree::FelNode, empty_message::Vector{<:Partition})
     for node in getnodelist(tree)
         if !isleafnode(node)
-            node.child_messages = [deepcopy(empty_message) for i in node.children]
+            node.child_messages = [copymessage(empty_message) for _ in node.children]
         end
-        node.message = deepcopy(empty_message)
-        node.parent_message = deepcopy(empty_message)
+        node.message = copymessage(empty_message)
+        node.parent_message = copymessage(empty_message)
     end
 end
 

--- a/src/models/discrete_models/discrete_partitions.jl
+++ b/src/models/discrete_models/discrete_partitions.jl
@@ -16,14 +16,15 @@ mutable struct CustomDiscretePartition <: DiscretePartition
     states::Int
     sites::Int
     scaling::Array{Float64,1}
-    function CustomDiscretePartition(states, sites)
-        new(zeros(states, sites), states, sites, zeros(sites))
-    end
-    function CustomDiscretePartition(freq_vec::Vector{Float64}, sites::Int64) #Add this constructor to all partition types
-        state_arr = zeros(length(freq_vec), sites)
-        state_arr .= freq_vec
-        new(state_arr, length(freq_vec), sites, zeros(sites))
-    end
+end
+
+CustomDiscretePartition(states, sites) =
+    CustomDiscretePartition(zeros(states, sites), states, sites, zeros(sites))
+
+function CustomDiscretePartition(freq_vec::Vector{Float64}, sites::Int64) #Add this constructor to all partition types
+    state_arr = zeros(length(freq_vec), sites)
+    state_arr .= freq_vec
+    return CustomDiscretePartition(state_arr, length(freq_vec), sites, zeros(sites))
 end
 
 mutable struct NucleotidePartition <: DiscretePartition
@@ -31,15 +32,15 @@ mutable struct NucleotidePartition <: DiscretePartition
     states::Int
     sites::Int
     scaling::Array{Float64,1}
-    function NucleotidePartition(sites)
-        new(zeros(4, sites), 4, sites, zeros(sites))
-    end
-    function NucleotidePartition(freq_vec::Vector{Float64}, sites::Int64)
-        @assert length(freq_vec) == 4
-        state_arr = zeros(4, sites)
-        state_arr .= freq_vec
-        new(state_arr, 4, sites, zeros(sites))
-    end
+end
+
+NucleotidePartition(sites) = NucleotidePartition(zeros(4, sites), 4, sites, zeros(sites))
+
+function NucleotidePartition(freq_vec::Vector{Float64}, sites::Int64)
+    @assert length(freq_vec) == 4
+    state_arr = zeros(4, sites)
+    state_arr .= freq_vec
+    return NucleotidePartition(state_arr, 4, sites, zeros(sites))
 end
 
 mutable struct GappyNucleotidePartition <: DiscretePartition
@@ -47,15 +48,15 @@ mutable struct GappyNucleotidePartition <: DiscretePartition
     states::Int
     sites::Int
     scaling::Array{Float64,1}
-    function GappyNucleotidePartition(sites)
-        new(zeros(5, sites), 5, sites, zeros(sites))
-    end
-    function GappyNucleotidePartition(freq_vec::Vector{Float64}, sites::Int64)
-        @assert length(freq_vec) == 5
-        state_arr = zeros(5, sites)
-        state_arr .= freq_vec
-        new(state_arr, 5, sites, zeros(sites))
-    end
+end
+
+GappyNucleotidePartition(sites) = GappyNucleotidePartition(zeros(5, sites), 5, sites, zeros(sites))
+
+function GappyNucleotidePartition(freq_vec::Vector{Float64}, sites::Int64)
+    @assert length(freq_vec) == 5
+    state_arr = zeros(5, sites)
+    state_arr .= freq_vec
+    return GappyNucleotidePartition(state_arr, 5, sites, zeros(sites))
 end
 
 mutable struct AminoAcidPartition <: DiscretePartition
@@ -63,15 +64,15 @@ mutable struct AminoAcidPartition <: DiscretePartition
     states::Int
     sites::Int
     scaling::Array{Float64,1}
-    function AminoAcidPartition(sites)
-        new(zeros(20, sites), 20, sites, zeros(sites))
-    end
-    function AminoAcidPartition(freq_vec::Vector{Float64}, sites::Int64)
-        @assert length(freq_vec) == 20
-        state_arr = zeros(20, sites)
-        state_arr .= freq_vec
-        new(state_arr, 20, sites, zeros(sites))
-    end
+end
+
+AminoAcidPartition(sites) = AminoAcidPartition(zeros(20, sites), 20, sites, zeros(sites))
+
+function AminoAcidPartition(freq_vec::Vector{Float64}, sites::Int64)
+    @assert length(freq_vec) == 20
+    state_arr = zeros(20, sites)
+    state_arr .= freq_vec
+    return AminoAcidPartition(state_arr, 20, sites, zeros(sites))
 end
 
 mutable struct GappyAminoAcidPartition <: DiscretePartition
@@ -79,15 +80,15 @@ mutable struct GappyAminoAcidPartition <: DiscretePartition
     states::Int
     sites::Int
     scaling::Array{Float64,1}
-    function GappyAminoAcidPartition(sites)
-        new(zeros(21, sites), 21, sites, zeros(sites))
-    end
-    function GappyAminoAcidPartition(freq_vec::Vector{Float64}, sites::Int64)
-        @assert length(freq_vec) == 21
-        state_arr = zeros(21, sites)
-        state_arr .= freq_vec
-        new(state_arr, 21, sites, zeros(sites))
-    end
+end
+
+GappyAminoAcidPartition(sites) = GappyAminoAcidPartition(zeros(21, sites), 21, sites, zeros(sites))
+
+function GappyAminoAcidPartition(freq_vec::Vector{Float64}, sites::Int64)
+    @assert length(freq_vec) == 21
+    state_arr = zeros(21, sites)
+    state_arr .= freq_vec
+    return GappyAminoAcidPartition(state_arr, 21, sites, zeros(sites))
 end
 
 function combine!(dest::DiscretePartition, src::DiscretePartition)


### PR DESCRIPTION
The `deepcopy` function is notorious for its bad performance in many cases. This pull request implements a method of the `copy` function for `Partition` to avoid calling the `deepcopy` function. The following example shows an extreme case to speed up initialization of a large tree:

```julia
tree = sim_tree(n = 1_000_000)
@time internal_message_init!(tree, GaussianPartition())
```

```
# main
kenta@KS-MBP ~/w/MolecularEvolution (opt-simtree)> julia example.jl 
 12.008125 seconds (50.00 M allocations: 3.178 GiB, 6.99% gc time, 0.01% compilation time)

# PR
kenta@KS-MBP ~/w/MolecularEvolution (copy-message)> julia example.jl
  1.121317 seconds (20.00 M allocations: 1.032 GiB)
```

Internal constructors of discrete partition types are moved out of the `struct` scopes because it eliminates the default constructor, which is needed to make the generic `copy` method work for all partition types.