### PR TITLE
optimize combine! for DiscretePartition

### DIFF
--- a/src/models/discrete_models/discrete_partitions.jl
+++ b/src/models/discrete_models/discrete_partitions.jl
@@ -102,9 +102,11 @@ function combine!(dest::DiscretePartition, src::DiscretePartition)
 
     # Re-scaling to prevent underflow
     dest.scaling .+= src.scaling
-    new_scaling = 1 ./ sum(dest.state, dims = 1)[:]
-    scale_cols_by_vec!(dest.state, new_scaling)
-    dest.scaling .+= -log.(new_scaling)
+    @views for j in axes(dest.state, 2)
+        scal = sum(dest.state[:,j])
+        dest.state[:,j] ./= scal
+        dest.scaling[j] += log(scal)
+    end
 end
 
 function identity!(dest::DiscretePartition)


### PR DESCRIPTION
This is a minor optimization of the `combine!` method of `DiscretePartition`, which avoids allocations entirely when scaling the likelihoods and shaves ~30% of allocations and ~10% of runtime in the `felsenstein_down!` case you (@murrellb) sent me via email.

main:
```
BenchmarkTools.Trial: 4236 samples with 1 evaluation.
 Range (min … max):  1.098 ms …   3.726 ms  ┊ GC (min … max): 0.00% … 66.00%
 Time  (median):     1.122 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   1.179 ms ± 347.161 μs  ┊ GC (mean ± σ):  4.27% ±  9.64%

  █▄▁▂                                                         
  ████▆▅▁▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▇█ █
  1.1 ms       Histogram: log(frequency) by time       3.5 ms <

 Memory estimate: 985.77 KiB, allocs estimate: 19971.
```

PR:
```
BenchmarkTools.Trial: 4833 samples with 1 evaluation.
 Range (min … max):  969.458 μs …   3.808 ms  ┊ GC (min … max): 0.00% … 69.61%
 Time  (median):     987.583 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):     1.034 ms ± 312.037 μs  ┊ GC (mean ± σ):  3.59% ±  8.47%

  █▄▂▁                                                          ▁
  ████▆▆▄▁▁▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▆▇ █
  969 μs        Histogram: log(frequency) by time       3.53 ms <

 Memory estimate: 673.89 KiB, allocs estimate: 14981.
```