### PR TITLE
make sibling_inds type stable

### DIFF
--- a/src/core/nodes/AbstractTreeNode.jl
+++ b/src/core/nodes/AbstractTreeNode.jl
@@ -485,9 +485,9 @@ Returns logical indices of the siblings in the parent's child's vector.
 """
 function sibling_inds(node::AbstractTreeNode)
     if isroot(node)
-        return [false]
+        return falses(1)
     else
-        return Ref(node) .!= node.parent.children
+        return (node,) .!= node.parent.children
     end
 end
 

--- a/src/core/nodes/FelNode.jl
+++ b/src/core/nodes/FelNode.jl
@@ -18,8 +18,6 @@ mutable struct FelNode <: AbstractTreeNode
     FelNode() = FelNode(0.0, "")
 end
 
-broadcastable(x::FelNode) = Ref(x) #???
-
 function Base.show(io::IO, z::FelNode)
     println(io, "FelNode")
     #println(io, "Type: ", typeof(z.branchlength))


### PR DESCRIPTION
This makes the `sibling_inds` function type-stable, which shaves a bit of memory allocation.

main
```
 Memory estimate: 985.77 KiB, allocs estimate: 19971.
```

PR
```
 Memory estimate: 970.17 KiB, allocs estimate: 18973.
```

Also, defining `broadcastable` of `FelNode` does not make much sense to me. So, I think we can safely remove the definition.