### PR TITLE
Add Brent's method for minimization

### DIFF
--- a/src/MolecularEvolution.jl
+++ b/src/MolecularEvolution.jl
@@ -29,7 +29,7 @@ abstract type SimulationModel <: BranchModel end #Simulation models typically ca
 
 abstract type StatePath end
 
-abstract type UnivariateOptimizer end
+abstract type UnivariateOpt end
 
 #include("core/core.jl")
 include("core/nodes/nodes.jl")
@@ -118,9 +118,9 @@ export
     one_hot_sample,
     scaled_prob_domain,
     golden_section_maximize,
-    GoldenSection,
+    GoldenSectionOpt,
     brents_method_minimize,
-    BrentsMethod,
+    BrentsMethodOpt,
     univariate_maximize,
     unit_transform,
     HKY85,

--- a/src/MolecularEvolution.jl
+++ b/src/MolecularEvolution.jl
@@ -116,6 +116,7 @@ export
     one_hot_sample,
     scaled_prob_domain,
     golden_section_maximize,
+    brents_method_minimize
     unit_transform,
     HKY85,
     P_from_diagonalized_Q,

--- a/src/MolecularEvolution.jl
+++ b/src/MolecularEvolution.jl
@@ -29,6 +29,8 @@ abstract type SimulationModel <: BranchModel end #Simulation models typically ca
 
 abstract type StatePath end
 
+abstract type UnivariateOptimizer end
+
 #include("core/core.jl")
 include("core/nodes/nodes.jl")
 include("core/algorithms/algorithms.jl")
@@ -116,7 +118,10 @@ export
     one_hot_sample,
     scaled_prob_domain,
     golden_section_maximize,
-    brents_method_minimize
+    GoldenSection,
+    brents_method_minimize,
+    BrentsMethod,
+    univariate_maximize,
     unit_transform,
     HKY85,
     P_from_diagonalized_Q,

--- a/src/core/algorithms/branchlength_optim.jl
+++ b/src/core/algorithms/branchlength_optim.jl
@@ -28,7 +28,7 @@ function branchlength_optim!(
     models,
     partition_list,
     tol;
-    bl_optimizer::UnivariateOptimizer = GoldenSection()
+    bl_optimizer::UnivariateOpt = GoldenSectionOpt()
 )
 
     #This bit of code should be identical to the regular downward pass...
@@ -90,16 +90,16 @@ end
 
 #BM: Check if running felsenstein_down! makes a difference.
 """
-    branchlength_optim!(tree::FelNode, models; partition_list = nothing, tol = 1e-5, bl_optimizer::UnivariateOptimizer = GoldenSection())
+    branchlength_optim!(tree::FelNode, models; partition_list = nothing, tol = 1e-5, bl_optimizer::UnivariateOpt = GoldenSectionOpt())
 
 Uses golden section search, or optionally Brent's method, to optimize all branches recursively, maintaining the integrity of the messages.
 Requires felsenstein!() to have been run first.
 models can either be a single model (if the messages on the tree contain just one Partition) or an array of models, if the messages have >1 Partition, or 
 a function that takes a node, and returns a Vector{<:BranchModel} if you need the models to vary from one branch to another.
 partition_list (eg. 1:3 or [1,3,5]) lets you choose which partitions to run over (but you probably want to optimize branch lengths with all models).
-tol is the tolerance for the bl_optimizer which defaults to golden section search, and has Brent's method as an option by setting bl_optimizer=BrentsMethod().
+tol is the absolute tolerance for the bl_optimizer which defaults to golden section search, and has Brent's method as an option by setting bl_optimizer=BrentsMethodOpt().
 """
-function branchlength_optim!(tree::FelNode, models; partition_list = nothing, tol = 1e-5, bl_optimizer::UnivariateOptimizer = GoldenSection())
+function branchlength_optim!(tree::FelNode, models; partition_list = nothing, tol = 1e-5, bl_optimizer::UnivariateOpt = GoldenSectionOpt())
     temp_message = deepcopy(tree.message)
     message_to_set = deepcopy(tree.message)
 
@@ -116,12 +116,12 @@ branchlength_optim!(
     models::Vector{<:BranchModel};
     partition_list = nothing,
     tol = 1e-5,
-    bl_optimizer::UnivariateOptimizer = GoldenSection()
+    bl_optimizer::UnivariateOpt = GoldenSectionOpt()
 ) = branchlength_optim!(tree, x -> models, partition_list = partition_list, tol = tol, bl_optimizer=bl_optimizer)
 branchlength_optim!(
     tree::FelNode,
     model::BranchModel;
     partition_list = nothing,
     tol = 1e-5,
-    bl_optimizer::UnivariateOptimizer = GoldenSection()
+    bl_optimizer::UnivariateOpt = GoldenSectionOpt()
 ) = branchlength_optim!(tree, x -> [model], partition_list = partition_list, tol = tol, bl_optimizer=bl_optimizer)

--- a/src/core/algorithms/branchlength_optim.jl
+++ b/src/core/algorithms/branchlength_optim.jl
@@ -77,7 +77,7 @@ function branchlength_optim!(
         if bl_optimizer == golden_section_maximize
             opt = golden_section_maximize(fun, 0 + tol, 1 - tol, unit_transform, tol)
         elseif bl_optimizer == brents_method_minimize
-            opt = brents_method_minimize(x -> -fun(x), 0 + tol, 1 - tol, tol/3) #See ?brents_method_minimize
+            opt = brents_method_minimize(x -> -fun(x), 0 + tol, 1 - tol, unit_transform, tol/3) #See ?brents_method_minimize
         end
         if fun(opt) > fun(node.branchlength)
             node.branchlength = opt

--- a/src/core/algorithms/branchlength_optim.jl
+++ b/src/core/algorithms/branchlength_optim.jl
@@ -28,7 +28,7 @@ function branchlength_optim!(
     models,
     partition_list,
     tol;
-    bl_optimizer=golden_section_maximize
+    bl_optimizer::Symbol=:golden_section_maximize
 )
 
     #This bit of code should be identical to the regular downward pass...
@@ -74,9 +74,9 @@ function branchlength_optim!(
     if !isroot(node)
         model_list = models(node)
         fun = x -> branch_LL_up(x, temp_message, node, model_list, partition_list)
-        if bl_optimizer == golden_section_maximize
+        if bl_optimizer == :golden_section_maximize
             opt = golden_section_maximize(fun, 0 + tol, 1 - tol, unit_transform, tol)
-        elseif bl_optimizer == brents_method_minimize
+        elseif bl_optimizer == :brents_method_minimize
             opt = brents_method_minimize(x -> -fun(x), 0 + tol, 1 - tol, unit_transform, tol/3) #See ?brents_method_minimize
         end
         if fun(opt) > fun(node.branchlength)
@@ -94,16 +94,16 @@ end
 
 #BM: Check if running felsenstein_down! makes a difference.
 """
-    branchlength_optim!(tree::FelNode, models; partition_list = nothing, tol = 1e-5)
+    branchlength_optim!(tree::FelNode, models; partition_list = nothing, tol = 1e-5, bl_optimizer::Symbol=:golden_section_maximize)
 
 Uses golden section search, or optionally Brent's method, to optimize all branches recursively, maintaining the integrity of the messages.
 Requires felsenstein!() to have been run first.
 models can either be a single model (if the messages on the tree contain just one Partition) or an array of models, if the messages have >1 Partition, or 
 a function that takes a node, and returns a Vector{<:BranchModel} if you need the models to vary from one branch to another.
 partition_list (eg. 1:3 or [1,3,5]) lets you choose which partitions to run over (but you probably want to optimize branch lengths with all models).
-tol is the tolerance for the bl_optimizer which defaults to golden section search, and has Brent's method as an option by setting bl_optimizer=brents_method_minimize.
+tol is the tolerance for the bl_optimizer which defaults to golden section search, and has Brent's method as an option by setting bl_optimizer=:brents_method_minimize.
 """
-function branchlength_optim!(tree::FelNode, models; partition_list = nothing, tol = 1e-5, bl_optimizer=golden_section_maximize)
+function branchlength_optim!(tree::FelNode, models; partition_list = nothing, tol = 1e-5, bl_optimizer::Symbol=:golden_section_maximize)
     temp_message = deepcopy(tree.message)
     message_to_set = deepcopy(tree.message)
 
@@ -120,12 +120,12 @@ branchlength_optim!(
     models::Vector{<:BranchModel};
     partition_list = nothing,
     tol = 1e-5,
-    bl_optimizer=golden_section_maximize
+    bl_optimizer::Symbol=:golden_section_maximize
 ) = branchlength_optim!(tree, x -> models, partition_list = partition_list, tol = tol, bl_optimizer=bl_optimizer)
 branchlength_optim!(
     tree::FelNode,
     model::BranchModel;
     partition_list = nothing,
     tol = 1e-5,
-    bl_optimizer=golden_section_maximize
+    bl_optimizer::Symbol=:golden_section_maximize
 ) = branchlength_optim!(tree, x -> [model], partition_list = partition_list, tol = tol, bl_optimizer=bl_optimizer)

--- a/src/utils/simple_optim.jl
+++ b/src/utils/simple_optim.jl
@@ -84,7 +84,7 @@ function SPI_is_well_behaved(a, b, x, p, q, prev_prev_e, tol)
 end
 
 """
-    brents_method_minimize(f, a::Real, b::Real, t::Real; ε::Real=sqrt(eps()))
+    brents_method_minimize(f, a::Real, b::Real, transform, t::Real; ε::Real=sqrt(eps()))
 Brent's method for minimization.
 
 Given a function f with a single local minimum in
@@ -107,16 +107,16 @@ with an order that's usually atleast 1.3247...
 julia> f(x) = exp(-x) - cos(x)
 f (generic function with 1 method)
 
-julia> m = brents_method_minimize(f, -1, 2, 1e-7)
+julia> m = brents_method_minimize(f, -1, 2, identity, 1e-7)
 0.5885327257940255
 ```
 
 From: Richard P. Brent, "Algorithms for Minimization without Derivatives" (1973). Chapter 5.
 """
-function brents_method_minimize(f, a::Real, b::Real, t::Real; ε::Real=sqrt(eps))
+function brents_method_minimize(f, a::Real, b::Real, transform, t::Real; ε::Real=sqrt(eps))
     a, b = min(a, b), max(a, b)
     v = w = x = a + invphi2 * (b - a) #x is our best approximation
-    fv = fw = fx = f(x) #We must always have that fv >= fw >= fx (1)
+    fv = fw = fx = f(transform(x)) #We must always have that fv >= fw >= fx (1)
 
     e, prev_e = 0, 0 #e denotes the step we take in each cycle
     m = (a + b) / 2
@@ -141,7 +141,7 @@ function brents_method_minimize(f, a::Real, b::Real, t::Real; ε::Real=sqrt(eps)
             e = e > 0 ? tol : -tol
         end
         u = x + e
-        fu = f(u)
+        fu = f(transform(u))
         #Update variables such that we satisfy (1) and discard the non-optimal interval
         if fu <= fx
             if u < x
@@ -168,7 +168,7 @@ function brents_method_minimize(f, a::Real, b::Real, t::Real; ε::Real=sqrt(eps)
         m = (a + b) / 2
         tol = ε * abs(x) + t
     end
-    return x
+    return transform(x)
 end
 
 

--- a/src/utils/simple_optim.jl
+++ b/src/utils/simple_optim.jl
@@ -67,6 +67,110 @@ function golden_section_maximize(f, a::Real, b::Real, transform, tol::Real)
     end
 end
 
+function brents_pq(x, w, v, fx, fw, fv)
+    #These are some values used by the SPI in  Brent's method
+    #x_new = x + p / q
+    p = (x - v)^2 * (fx - fw) - (x - w)^2 * (fx - fv)
+    q = 2 * ((x - v) * (fx - fw) - (x - w) * (fx - fv))
+    if q > 0
+        p = -p
+    end
+    q = abs(q)
+    return p, q
+end
+
+function SPI_is_well_behaved(a, b, x, p, q, prev_prev_e, tol)
+    return (q != 0 && a < x + p / q < b && abs(p / q) < abs(prev_prev_e) / 2 && abs(prev_prev_e) > tol)
+end
+
+"""
+    brents_method_minimize(f, a::Real, b::Real, t::Real; ε::Real=sqrt(eps()))
+Brent's method for minimization.
+
+Given a function f with a single local minimum in
+the interval (a,b), Brent's method returns an approximation
+of the x-value that minimizes f to an accuaracy between 2tol and 3tol,
+where tol is a combination of a relative and an absolute tolerance,
+`tol := ε|x| + t`. ε should be no smaller `2*eps`,
+and preferably not much less than `sqrt(eps)`, which is also the default value.
+eps is defined here as the machine epsilon in double precision.
+t should be positive.
+
+The method combines the stability of a Golden Section Search and the superlinear convergence
+Successive Parabolic Interpolation has under certain conditions. The method never converges much slower
+than a Fibonacci search and for a sufficiently well-behaved f, convergence can be exptected to be superlinear,
+with an order that's usually atleast 1.3247...
+
+# Examples
+
+```jldoctest
+julia> f(x) = exp(-x) - cos(x)
+f (generic function with 1 method)
+
+julia> m = brents_method_minimize(f, -1, 2, 1e-7)
+0.5885327257940255
+```
+
+From: Richard P. Brent, "Algorithms for Minimization without Derivatives" (1973). Chapter 5.
+"""
+function brents_method_minimize(f, a::Real, b::Real, t::Real; ε::Real=sqrt(eps))
+    a, b = min(a, b), max(a, b)
+    v = w = x = a + invphi2 * (b - a) #x is our best approximation
+    fv = fw = fx = f(x) #We must always have that fv >= fw >= fx (1)
+
+    e, prev_e = 0, 0 #e denotes the step we take in each cycle
+    m = (a + b) / 2
+    tol = ε * abs(x) + t
+
+    while abs(x - m) > 2*tol - (b - a) / 2
+        prev_prev_e = prev_e
+        prev_e = e
+        p, q = brents_pq(x, w, v, fx, fw, fv)
+        if SPI_is_well_behaved(a, b, x, p, q, prev_prev_e, tol)
+            #Then we do a "parabolic interpolation" step
+            e = p / q
+            u = x + e
+            if u - a < 2*tol || b - u < 2*tol #f must not be evaluated too close to a or b
+                e = x < m ? tol : -tol
+            end
+        else #We fall back to a "golden section" step
+            prev_e = x < m ? b - x : a - x #We want our prev_prev_e to inherit this value, since two GSS steps two iterations apart differ by a factor of invphi2
+            e = invphi2 * prev_e
+        end
+        if abs(e) < tol #f must not be evaluated too close to x
+            e = e > 0 ? tol : -tol
+        end
+        u = x + e
+        fu = f(u)
+        #Update variables such that we satisfy (1) and discard the non-optimal interval
+        if fu <= fx
+            if u < x
+                b = x
+            else
+                a = x
+            end
+            v, fv = w, fw
+            w, fw = x, fx
+            x, fx = u, fu
+        else
+            if u < x
+                a = u
+            else
+                b = u
+            end
+            if fu <= fw || w == x
+                v, fv = w, fw
+                w, fw = u, fu
+            elseif fu <= fv || v == x || v == w
+                v, fv = u, fu
+            end
+        end
+        m = (a + b) / 2
+        tol = ε * abs(x) + t
+    end
+    return x
+end
+
 
 #This is SGD on trees, sampling branches (using the stochastic_ll_diffs function).
 #Promising, but need a LOT of testing. See the FUBAR notebook for a use example.

--- a/src/utils/simple_optim.jl
+++ b/src/utils/simple_optim.jl
@@ -12,6 +12,9 @@ function unit_inv_transform(x::Real; k = 1.0)
     x / (x + k)
 end
 
+struct GoldenSection <: UnivariateOptimizer end
+struct BrentsMethod <: UnivariateOptimizer end
+
 """
 Golden section search.
 
@@ -67,6 +70,23 @@ function golden_section_maximize(f, a::Real, b::Real, transform, tol::Real)
     end
 end
 
+"""
+    univariate_maximize(f, a::Real, b::Real, transform, optimizer::GoldenSection, tol::Real)
+Maximizes `f(x)` using a Golden Section Search. See `?golden_section_maximize`.
+# Examples
+
+```jldoctest
+julia> f(x) = -(x-2)^2
+f (generic function with 1 method)
+
+julia> m = univariate_maximize(f, 1, 5, identity, GoldenSection(), 1e-10)
+2.0000000000051843
+```
+"""
+function univariate_maximize(f, a::Real, b::Real, transform, optimizer::GoldenSection, tol::Real)
+    return golden_section_maximize(f, a, b, transform, tol)
+end
+
 function brents_pq(x, w, v, fx, fw, fv)
     #These are some values used by the SPI in  Brent's method
     #x_new = x + p / q
@@ -91,7 +111,7 @@ Given a function f with a single local minimum in
 the interval (a,b), Brent's method returns an approximation
 of the x-value that minimizes f to an accuaracy between 2tol and 3tol,
 where tol is a combination of a relative and an absolute tolerance,
-`tol := ε|x| + t`. ε should be no smaller `2*eps`,
+tol := ε|x| + t. ε should be no smaller `2*eps`,
 and preferably not much less than `sqrt(eps)`, which is also the default value.
 eps is defined here as the machine epsilon in double precision.
 t should be positive.
@@ -169,6 +189,15 @@ function brents_method_minimize(f, a::Real, b::Real, transform, t::Real; ε::Rea
         tol = ε * abs(x) + t
     end
     return transform(x)
+end
+
+"""
+    univariate_maximize(f, a::Real, b::Real, transform, optimizer::BrentsMethod, t::Real; ε::Real=sqrt(eps))
+Maximizes `f(x)` using Brent's method.
+See `?brents_method_minimize`.
+"""
+function univariate_maximize(f, a::Real, b::Real, transform, optimizer::BrentsMethod, t::Real; ε::Real=sqrt(eps))
+    return brents_method_minimize(x -> -f(x), a, b, transform, t, ε = ε)
 end
 
 

--- a/src/utils/simple_optim.jl
+++ b/src/utils/simple_optim.jl
@@ -12,8 +12,8 @@ function unit_inv_transform(x::Real; k = 1.0)
     x / (x + k)
 end
 
-struct GoldenSection <: UnivariateOptimizer end
-struct BrentsMethod <: UnivariateOptimizer end
+struct GoldenSectionOpt <: UnivariateOpt end
+struct BrentsMethodOpt <: UnivariateOpt end
 
 """
 Golden section search.
@@ -71,7 +71,7 @@ function golden_section_maximize(f, a::Real, b::Real, transform, tol::Real)
 end
 
 """
-    univariate_maximize(f, a::Real, b::Real, transform, optimizer::GoldenSection, tol::Real)
+    univariate_maximize(f, a::Real, b::Real, transform, optimizer::GoldenSectionOpt, tol::Real)
 Maximizes `f(x)` using a Golden Section Search. See `?golden_section_maximize`.
 # Examples
 
@@ -79,11 +79,11 @@ Maximizes `f(x)` using a Golden Section Search. See `?golden_section_maximize`.
 julia> f(x) = -(x-2)^2
 f (generic function with 1 method)
 
-julia> m = univariate_maximize(f, 1, 5, identity, GoldenSection(), 1e-10)
+julia> m = univariate_maximize(f, 1, 5, identity, GoldenSectionOpt(), 1e-10)
 2.0000000000051843
 ```
 """
-function univariate_maximize(f, a::Real, b::Real, transform, optimizer::GoldenSection, tol::Real)
+function univariate_maximize(f, a::Real, b::Real, transform, optimizer::GoldenSectionOpt, tol::Real)
     return golden_section_maximize(f, a, b, transform, tol)
 end
 
@@ -192,11 +192,11 @@ function brents_method_minimize(f, a::Real, b::Real, transform, t::Real; ε::Rea
 end
 
 """
-    univariate_maximize(f, a::Real, b::Real, transform, optimizer::BrentsMethod, t::Real; ε::Real=sqrt(eps))
+    univariate_maximize(f, a::Real, b::Real, transform, optimizer::BrentsMethodOpt, t::Real; ε::Real=sqrt(eps))
 Maximizes `f(x)` using Brent's method.
 See `?brents_method_minimize`.
 """
-function univariate_maximize(f, a::Real, b::Real, transform, optimizer::BrentsMethod, t::Real; ε::Real=sqrt(eps))
+function univariate_maximize(f, a::Real, b::Real, transform, optimizer::BrentsMethodOpt, t::Real; ε::Real=sqrt(eps))
     return brents_method_minimize(x -> -f(x), a, b, transform, t, ε = ε)
 end
 

--- a/test/partition_selection.jl
+++ b/test/partition_selection.jl
@@ -53,18 +53,11 @@ begin
     felsenstein_down!(tree, x -> bm_models, partition_list = [2])
     felsenstein_down!(tree, x -> bm_models)
 
-    tol = 1e-5
-    unopt_tree_copy = deepcopy(tree)
-    branchlength_optim!(tree, bm_models, tol=tol)
-    branchlength_sample_under_gss = tree.children[1].branchlength
-    branchlength_optim!(unopt_tree_copy, bm_models, tol=tol, bl_optimizer=BrentsMethod())
-    branchlength_sample_under_brent = unopt_tree_copy.children[1].branchlength
-    @test isapprox(
-        MolecularEvolution.unit_inv_transform(branchlength_sample_under_gss), #We're optimizing the untransformed values in the unit domain
-        MolecularEvolution.unit_inv_transform(branchlength_sample_under_brent), 
-        atol=4*tol) #Brent ensures an accuracy of 3*tol in this case, which is why we choose 4*tol.
+    #TODO When we use BrentsMethodOpt, check if we gain a speed-up and that we're not catastrophically wrong
     branchlength_optim!(tree, bm_models, partition_list = [1])
     branchlength_optim!(tree, bm_models, partition_list = [2])
+    branchlength_optim!(tree, bm_models)
+    branchlength_optim!(tree, bm_models, bl_optimizer=BrentsMethodOpt())
     branchlength_optim!(tree, x -> bm_models, partition_list = [2])
     branchlength_optim!(tree, x -> bm_models)
 

--- a/test/partition_selection.jl
+++ b/test/partition_selection.jl
@@ -4,7 +4,7 @@ begin
     nuc_partition = NucleotidePartition(10)
     nuc_partition.state .= 0.25
     internal_message_init!(tree, [nuc_partition, GaussianPartition()])
-    Q = HKY85(4.0, 0.25, 0.25, 0.25, 0.25) .* 0.001
+    Q = MolecularEvolution.HKY85(4.0, 0.25, 0.25, 0.25, 0.25) .* 0.001
     bm_models = [DiagonalizedCTMC(Q), BrownianMotion(0.0, 0.1)]
     sample_down!(tree, bm_models)
     log_likelihood!(tree, bm_models)
@@ -56,6 +56,10 @@ begin
     branchlength_optim!(tree, bm_models, partition_list = [1])
     branchlength_optim!(tree, bm_models, partition_list = [2])
     branchlength_optim!(tree, bm_models)
+    tree_branchlength_under_gss = tree.branchlength
+    branchlength_optim!(tree, bm_models, bl_optimizer=brents_method_minimize)
+    tree_branchlength_under_brent = tree.branchlength
+    @test isapprox(tree_branchlength_under_gss, tree_branchlength_under_brent, atol=1e-5)
     branchlength_optim!(tree, x -> bm_models, partition_list = [2])
     branchlength_optim!(tree, x -> bm_models)
 

--- a/test/partition_selection.jl
+++ b/test/partition_selection.jl
@@ -53,13 +53,18 @@ begin
     felsenstein_down!(tree, x -> bm_models, partition_list = [2])
     felsenstein_down!(tree, x -> bm_models)
 
+    tol = 1e-5
+    unopt_tree_copy = deepcopy(tree)
+    branchlength_optim!(tree, bm_models, tol=tol)
+    branchlength_sample_under_gss = tree.children[1].branchlength
+    branchlength_optim!(unopt_tree_copy, bm_models, tol=tol, bl_optimizer=:brents_method_minimize)
+    branchlength_sample_under_brent = unopt_tree_copy.children[1].branchlength
+    @test isapprox(
+        MolecularEvolution.unit_inv_transform(branchlength_sample_under_gss), #We're optimizing the untransformed values in the unit domain
+        MolecularEvolution.unit_inv_transform(branchlength_sample_under_brent), 
+        atol=2*tol)
     branchlength_optim!(tree, bm_models, partition_list = [1])
     branchlength_optim!(tree, bm_models, partition_list = [2])
-    branchlength_optim!(tree, bm_models)
-    tree_branchlength_under_gss = tree.branchlength
-    branchlength_optim!(tree, bm_models, bl_optimizer=brents_method_minimize)
-    tree_branchlength_under_brent = tree.branchlength
-    @test isapprox(tree_branchlength_under_gss, tree_branchlength_under_brent, atol=1e-5)
     branchlength_optim!(tree, x -> bm_models, partition_list = [2])
     branchlength_optim!(tree, x -> bm_models)
 

--- a/test/test_optim.jl
+++ b/test/test_optim.jl
@@ -2,7 +2,7 @@ begin
     f(x) = -(x - 2)^2
     m = golden_section_maximize(f, 1, 5, identity, 1e-20)
     @test m == 2.0
-    m = brents_method_minimize(x -> -f(x), 1, 5, 1e-20)
+    m = brents_method_minimize(x -> -f(x), 1, 5, identity, 1e-20)
     @test m == 2.0
 end
 

--- a/test/test_optim.jl
+++ b/test/test_optim.jl
@@ -2,6 +2,8 @@ begin
     f(x) = -(x - 2)^2
     m = golden_section_maximize(f, 1, 5, identity, 1e-20)
     @test m == 2.0
+    m = brents_method_minimize(x -> -f(x), 1, 5, 1e-20)
+    @test m == 2.0
 end
 
 begin


### PR DESCRIPTION
This pull request implements Brent's method for minimization and calls it `brents_method_minimize`. It also makes it an option as an optimizer for `branchlength_optim!`. This method can be used for 1D unimodal optimization problems and it doesn't use derivatives.

Additionally, this pull request generalizes `golden_section_maximize` and `brents_method_minimize` with `univariate_maximize`. It dispatches on the two different subtypes, `GoldenSectionOpt`and `BrentsMethodOpt`, of the new `UnivariateOpt`-type.