### PR TITLE
Avoid deepcopy pt. 2

### DIFF
--- a/src/MolecularEvolution.jl
+++ b/src/MolecularEvolution.jl
@@ -129,6 +129,7 @@ export
 
     #things the user might overload
     copy_partition_to!,
+    copy_partition,
     equilibrium_message,
     sample_partition!,
     obs2partition!,

--- a/src/core/nodes/FelNode.jl
+++ b/src/core/nodes/FelNode.jl
@@ -60,10 +60,10 @@ end
 function internal_message_init!(tree::FelNode, empty_message::Vector{<:Partition})
     for node in getnodelist(tree)
         if !isleafnode(node)
-            node.child_messages = [deepcopy(empty_message) for i in node.children]
+            node.child_messages = [copy_message(empty_message) for i in node.children]
         end
-        node.message = deepcopy(empty_message)
-        node.parent_message = deepcopy(empty_message)
+        node.message = copy_message(empty_message)
+        node.parent_message = copy_message(empty_message)
     end
 end
 

--- a/src/models/continuous_models/gaussian_partition.jl
+++ b/src/models/continuous_models/gaussian_partition.jl
@@ -15,6 +15,11 @@ mutable struct GaussianPartition <: ContinuousPartition
     end
 end
 
+#Overloading the copy_partition to avoid deepcopy.
+function copy_partition(src::GaussianPartition)
+    return GaussianPartition(src.mean, src.var, src.norm_const)
+end
+
 #From the first section of http://www.tina-vision.net/docs/memos/2003-003.pdf
 function merge_two_gaussians(g1::GaussianPartition, g2::GaussianPartition)
     #Handling some edge cases. These aren't mathematically sensible. A gaussian with "Inf" variance will behave like a 1,1,1,1 vector in discrete felsenstein.

--- a/src/models/discrete_models/discrete_partitions.jl
+++ b/src/models/discrete_models/discrete_partitions.jl
@@ -10,20 +10,26 @@ function copy_partition_to!(dest::T, src::T) where {T<:DiscretePartition}
     dest.scaling .= src.scaling
 end
 
+#Overloading the copy_partition to avoid deepcopy.
+function copy_partition(src::T) where {T<:DiscretePartition}
+    return T(ntuple(i -> copy(getfield(src, i)), fieldcount(T))...)
+end
+
 #I should add a constructor that constructs a DiscretePartition from an existing array.
 mutable struct CustomDiscretePartition <: DiscretePartition
     state::Array{Float64,2}
     states::Int
     sites::Int
     scaling::Array{Float64,1}
-    function CustomDiscretePartition(states, sites)
-        new(zeros(states, sites), states, sites, zeros(sites))
-    end
-    function CustomDiscretePartition(freq_vec::Vector{Float64}, sites::Int64) #Add this constructor to all partition types
-        state_arr = zeros(length(freq_vec), sites)
-        state_arr .= freq_vec
-        new(state_arr, length(freq_vec), sites, zeros(sites))
-    end
+end
+
+CustomDiscretePartition(states, sites) =
+    CustomDiscretePartition(zeros(states, sites), states, sites, zeros(sites))
+
+function CustomDiscretePartition(freq_vec::Vector{Float64}, sites::Int64) #Add this constructor to all partition types
+    state_arr = zeros(length(freq_vec), sites)
+    state_arr .= freq_vec
+    return CustomDiscretePartition(state_arr, length(freq_vec), sites, zeros(sites))
 end
 
 mutable struct NucleotidePartition <: DiscretePartition
@@ -31,15 +37,15 @@ mutable struct NucleotidePartition <: DiscretePartition
     states::Int
     sites::Int
     scaling::Array{Float64,1}
-    function NucleotidePartition(sites)
-        new(zeros(4, sites), 4, sites, zeros(sites))
-    end
-    function NucleotidePartition(freq_vec::Vector{Float64}, sites::Int64)
-        @assert length(freq_vec) == 4
-        state_arr = zeros(4, sites)
-        state_arr .= freq_vec
-        new(state_arr, 4, sites, zeros(sites))
-    end
+end
+
+NucleotidePartition(sites) = NucleotidePartition(zeros(4, sites), 4, sites, zeros(sites))
+
+function NucleotidePartition(freq_vec::Vector{Float64}, sites::Int64)
+    @assert length(freq_vec) == 4
+    state_arr = zeros(4, sites)
+    state_arr .= freq_vec
+    return NucleotidePartition(state_arr, 4, sites, zeros(sites))
 end
 
 mutable struct GappyNucleotidePartition <: DiscretePartition
@@ -47,15 +53,15 @@ mutable struct GappyNucleotidePartition <: DiscretePartition
     states::Int
     sites::Int
     scaling::Array{Float64,1}
-    function GappyNucleotidePartition(sites)
-        new(zeros(5, sites), 5, sites, zeros(sites))
-    end
-    function GappyNucleotidePartition(freq_vec::Vector{Float64}, sites::Int64)
-        @assert length(freq_vec) == 5
-        state_arr = zeros(5, sites)
-        state_arr .= freq_vec
-        new(state_arr, 5, sites, zeros(sites))
-    end
+end
+
+GappyNucleotidePartition(sites) = GappyNucleotidePartition(zeros(5, sites), 5, sites, zeros(sites))
+
+function GappyNucleotidePartition(freq_vec::Vector{Float64}, sites::Int64)
+    @assert length(freq_vec) == 5
+    state_arr = zeros(5, sites)
+    state_arr .= freq_vec
+    return GappyNucleotidePartition(state_arr, 5, sites, zeros(sites))
 end
 
 mutable struct AminoAcidPartition <: DiscretePartition
@@ -63,15 +69,15 @@ mutable struct AminoAcidPartition <: DiscretePartition
     states::Int
     sites::Int
     scaling::Array{Float64,1}
-    function AminoAcidPartition(sites)
-        new(zeros(20, sites), 20, sites, zeros(sites))
-    end
-    function AminoAcidPartition(freq_vec::Vector{Float64}, sites::Int64)
-        @assert length(freq_vec) == 20
-        state_arr = zeros(20, sites)
-        state_arr .= freq_vec
-        new(state_arr, 20, sites, zeros(sites))
-    end
+end
+
+AminoAcidPartition(sites) = AminoAcidPartition(zeros(20, sites), 20, sites, zeros(sites))
+
+function AminoAcidPartition(freq_vec::Vector{Float64}, sites::Int64)
+    @assert length(freq_vec) == 20
+    state_arr = zeros(20, sites)
+    state_arr .= freq_vec
+    return AminoAcidPartition(state_arr, 20, sites, zeros(sites))
 end
 
 mutable struct GappyAminoAcidPartition <: DiscretePartition
@@ -79,15 +85,15 @@ mutable struct GappyAminoAcidPartition <: DiscretePartition
     states::Int
     sites::Int
     scaling::Array{Float64,1}
-    function GappyAminoAcidPartition(sites)
-        new(zeros(21, sites), 21, sites, zeros(sites))
-    end
-    function GappyAminoAcidPartition(freq_vec::Vector{Float64}, sites::Int64)
-        @assert length(freq_vec) == 21
-        state_arr = zeros(21, sites)
-        state_arr .= freq_vec
-        new(state_arr, 21, sites, zeros(sites))
-    end
+end
+
+GappyAminoAcidPartition(sites) = GappyAminoAcidPartition(zeros(21, sites), 21, sites, zeros(sites))
+
+function GappyAminoAcidPartition(freq_vec::Vector{Float64}, sites::Int64)
+    @assert length(freq_vec) == 21
+    state_arr = zeros(21, sites)
+    state_arr .= freq_vec
+    return GappyAminoAcidPartition(state_arr, 21, sites, zeros(sites))
 end
 
 """

--- a/src/models/models.jl
+++ b/src/models/models.jl
@@ -21,6 +21,20 @@ function copy_partition_to!(dest::GaussianPartition,src::GaussianPartition)
 end
 =#
 
+#Fallback method. This should be overloaded to avoid deepcopy wherever performance requires it
+function copy_partition(src::T) where {T <: Partition}
+    return deepcopy(src)
+end
+
+#Example overloading for GaussianPartition:
+#=
+function copy_partition(src::GaussianPartition)
+    return GaussianPartition(src.mean, src.var, src.norm_const)
+end
+=#
+
+copy_message(msg::Vector{<:Partition}) = [copy_partition(x) for x in msg]
+
 #This is a function shared for all models - perhaps move this elsewhere
 function combine!(dest::T, source_arr::Vector{<:T}, wipe::Bool) where {T<:Partition}
     #Init to be equal to 1, then multiply everything on.


### PR DESCRIPTION
Follow up to PR #6 
-------------------------------
-Implements `copy_partition`, which falls back to `deepcopy` but is overloaded for `<:DiscretePartition` and `GaussianPartition` in this PR. 
-`copy_message` is implemented as the trivial generalization of `copy_partition`. 
-`deepcopy` calls are replaced with `copy_message` calls in `internal_message_init!`. 

Note: It is meant for `copy_partition` and `copy_message` to replace `deepcopy` calls throughout the whole package. A follow up PR will carry out the rest of these replacements.

Example with GaussianPartition:
```
tree = sim_tree(n = 1_000_000)
@time internal_message_init!(tree, GaussianPartition())

# main
 10.450746 seconds (50.00 M allocations: 3.178 GiB, 19.87% gc time, 0.05% compilation time)

# PR
 1.794678 seconds (20.00 M allocations: 1.032 GiB, 46.68% gc time)
```

Example with NucleotidePartition:
```
tree = sim_tree(n = 100_000)
@time internal_message_init!(tree, NucleotidePartition(30))

# main
 1.075276 seconds (4.43 M allocations: 1.081 GiB, 23.23% gc time, 1.02% compilation time)

# PR
 0.416153 seconds (3.20 M allocations: 912.376 MiB, 58.30% gc time)
```

Example with both:
```
tree = sim_tree(n = 100_000)
@time internal_message_init!(tree, [GaussianPartition(), NucleotidePartition(30)])

# main
 1.759613 seconds (6.13 M allocations: 1.084 GiB, 13.33% gc time, 0.63% compilation time)

# PR
 0.703235 seconds (6.36 M allocations: 1003.178 MiB, 34.50% gc time, 13.22% compilation time)
```