### PR TITLE
Replace deepcopy

### DIFF
--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -314,7 +314,7 @@ function objective(params::NamedTuple; tree = tree)
     #Optim inside optim
     #We first need to handle the merge of the parent and root partitions - usually handled for us magically!
     #Be careful: this example is hard-coded for a single partition
-    temp_part = deepcopy(tree.parent_message[1])
+    temp_part = copy_partition(tree.parent_message[1])
     combine!(temp_part, tree.message[1])
     θ,LL = opt_weights_and_LL(temp_part)
     return -LL
@@ -332,7 +332,7 @@ final_params = unflatten(mini)
 optimized_model = build_model_vec(final_params)
 
 felsenstein!(tree,optimized_model)
-temp_part = deepcopy(tree.parent_message[1])
+temp_part = copy_partition(tree.parent_message[1])
 combine!(temp_part, tree.message[1])
 θ,_ = opt_weights_and_LL(temp_part, iters = 1000) #polish weights for final pass - quick
 optimized_model.weights .= θ

--- a/src/MolecularEvolution.jl
+++ b/src/MolecularEvolution.jl
@@ -130,6 +130,7 @@ export
     #things the user might overload
     copy_partition_to!,
     copy_partition,
+    copy_message,
     equilibrium_message,
     sample_partition!,
     obs2partition!,

--- a/src/core/algorithms/ancestors.jl
+++ b/src/core/algorithms/ancestors.jl
@@ -98,7 +98,7 @@ function reconstruct_marginal_node!(
 )
     #Note: these family of functions can be passed a dictionary for repeat use, but then the "structure" must be unchanged.
     if !haskey(node_message_dict, node)
-        node_message_dict[node] = deepcopy(node.message[partition_list])
+        node_message_dict[node] = copy_message(node.message[partition_list])
     end
     m = node_message_dict[node]
     for (p, part) in enumerate(partition_list)
@@ -140,7 +140,7 @@ function dependent_reconstruction!(
     f! = x -> nothing,
 )
     if !haskey(node_message_dict, node)
-        node_message_dict[node] = deepcopy(node.message[partition_list])
+        node_message_dict[node] = copy_message(node.message[partition_list])
     end
     m = node_message_dict[node]
     for (p, part) in enumerate(partition_list)

--- a/src/core/algorithms/branchlength_optim.jl
+++ b/src/core/algorithms/branchlength_optim.jl
@@ -39,7 +39,7 @@ function branchlength_optim!(
             forward!(temp_message[part], node.parent_message[part], model_list[part], node)
         end
         for i = 1:length(node.children)
-            new_temp = deepcopy(temp_message) #Need to think of how to avoid this allocation. Same as in felsenstein_down
+            new_temp = copy_message(temp_message) #Need to think of how to avoid this allocation. Same as in felsenstein_down
             sib_inds = sibling_inds(node.children[i])
             for part in partition_list
                 combine!(
@@ -100,8 +100,8 @@ partition_list (eg. 1:3 or [1,3,5]) lets you choose which partitions to run over
 tol is the absolute tolerance for the bl_optimizer which defaults to golden section search, and has Brent's method as an option by setting bl_optimizer=BrentsMethodOpt().
 """
 function branchlength_optim!(tree::FelNode, models; partition_list = nothing, tol = 1e-5, bl_optimizer::UnivariateOpt = GoldenSectionOpt())
-    temp_message = deepcopy(tree.message)
-    message_to_set = deepcopy(tree.message)
+    temp_message = copy_message(tree.message)
+    message_to_set = copy_message(tree.message)
 
     if partition_list === nothing
         partition_list = 1:length(tree.message)

--- a/src/core/algorithms/felsenstein.jl
+++ b/src/core/algorithms/felsenstein.jl
@@ -76,7 +76,7 @@ function felsenstein!(
 end
 
 """
-    felsenstein_down!(node::FelNode, models; partition_list = 1:length(tree.message), temp_message = deepcopy(tree.message))
+    felsenstein_down!(node::FelNode, models; partition_list = 1:length(tree.message), temp_message = copy_message(tree.message))
 
 Should usually be called on the root of the tree. Propagates Felsenstein pass down from the root to the tips.
 felsenstein!() should usually be called first.
@@ -88,7 +88,7 @@ function felsenstein_down!(
     tree::FelNode,
     models;
     partition_list = 1:length(tree.message),
-    temp_message = deepcopy(tree.message),
+    temp_message = copy_message(tree.message),
 )
     stack = [tree]
     #curr = nothing
@@ -141,7 +141,7 @@ function felsenstein_down!(
     tree::FelNode,
     models::Vector{<:BranchModel};
     partition_list = 1:length(tree.message),
-    temp_message = deepcopy(tree.message),
+    temp_message = copy_message(tree.message),
 )
     felsenstein_down!(
         tree,
@@ -155,7 +155,7 @@ function felsenstein_down!(
     tree::FelNode,
     model::BranchModel;
     partition_list = 1:length(tree.message),
-    temp_message = deepcopy(tree.message),
+    temp_message = copy_message(tree.message),
 )
     felsenstein_down!(
         tree,

--- a/src/core/algorithms/lls.jl
+++ b/src/core/algorithms/lls.jl
@@ -12,7 +12,7 @@ end
 
 function log_likelihood(tree::FelNode, model_func; partition_list = 1:length(tree.message))
     #Just combines root message with equilibrium message
-    temp_message = deepcopy(tree.parent_message[partition_list])
+    temp_message = copy_message(tree.parent_message[partition_list])
     models = model_func(tree)
     for (p, part) in enumerate(partition_list)
         #if tree.branchlength > 0.0 #Consider this - requires a (reasonable) assumption about model behavior.

--- a/src/core/algorithms/nni_optim.jl
+++ b/src/core/algorithms/nni_optim.jl
@@ -23,7 +23,7 @@ function nni_optim!(
     end
     @assert length(node.children) <= 2
     for i = 1:length(node.children)
-        new_temp = deepcopy(temp_message) #Need to think of how to avoid this allocation. Same as in felsenstein_down
+        new_temp = copy_message(temp_message) #Need to think of how to avoid this allocation. Same as in felsenstein_down
         sib_inds = sibling_inds(node.children[i])
         for part in partition_list
             combine!(
@@ -116,7 +116,7 @@ function do_nni(
     if length(node.children) == 0 || node.parent === nothing
         return false
     else
-        temp_message2 = deepcopy(temp_message)
+        temp_message2 = copy_message(temp_message)
         model_list = models(node)
         #current score
         for part in partition_list
@@ -231,8 +231,8 @@ function nni_optim!(
     partition_list = nothing,
     acc_rule = (x, y) -> x > y,
 )
-    temp_message = deepcopy(tree.message)
-    message_to_set = deepcopy(tree.message)
+    temp_message = copy_message(tree.message)
+    message_to_set = copy_message(tree.message)
 
     if partition_list === nothing
         partition_list = 1:length(tree.message)

--- a/src/core/nodes/FelNode.jl
+++ b/src/core/nodes/FelNode.jl
@@ -78,7 +78,7 @@ end
 
 function random_leaf_init!(tree::FelNode, empty_message::Vector{<:Partition})
     for node in getleaflist(tree)
-        node.message = deepcopy(empty_message)
+        node.message = copy_message(empty_message)
         for part in node.message
             for site = 1:part.sites
                 part.state[rand(1:part.states), site] = 1.0
@@ -92,7 +92,7 @@ function mixed_type_equilibrium_message(
     model_vec::Vector{<:BranchModel},
     message_template::Vector{<:Partition},
 )
-    out_mess = deepcopy(message_template)
+    out_mess = copy_message(message_template)
     for part = 1:length(message_template)
         out_mess[part] = eq_freq_from_template(model_vec[part], message_template[part])
     end

--- a/src/models/continuous_models/brownian_motion.jl
+++ b/src/models/continuous_models/brownian_motion.jl
@@ -31,7 +31,7 @@ end
 
 #If you want to use a root prior, you can set these values explicitly.
 function eq_freq_from_template(model::BrownianMotion, partition_template::GaussianPartition)
-    out_partition = deepcopy(partition_template)
+    out_partition = copy_partition(partition_template)
     out_partition.mean = 0.0
     out_partition.var = Inf
     out_partition.norm_const = 0.0

--- a/src/models/continuous_models/gaussian_partition.jl
+++ b/src/models/continuous_models/gaussian_partition.jl
@@ -27,16 +27,16 @@ function merge_two_gaussians(g1::GaussianPartition, g2::GaussianPartition)
     if g1.var == 0 && g2.var == 0 && g1.var != g2.var
         error("both gaussians have 0 variance but different means")
     elseif g1.var == 0
-        return deepcopy(g1)
+        return copy_partition(g1)
     elseif g2.var == 0
-        return deepcopy(g2)
+        return copy_partition(g2)
     end
     if g1.var == Inf && g2.var == Inf
         return GaussianPartition((g1.mean + g2.mean) / 2, Inf, 0.0)
     elseif g1.var == Inf
-        return deepcopy(g2)
+        return copy_partition(g2)
     elseif g2.var == Inf
-        return deepcopy(g1)
+        return copy_partition(g1)
     end
     res_gaussian = GaussianPartition()
     res_gaussian.var = 1 / (1 / g1.var + 1 / g2.var)

--- a/src/models/continuous_models/ornstein_uhlenbeck.jl
+++ b/src/models/continuous_models/ornstein_uhlenbeck.jl
@@ -33,7 +33,7 @@ function eq_freq_from_template(
     model::ZeroDriftOrnsteinUhlenbeck,
     partition_template::GaussianPartition,
 )
-    out_partition = deepcopy(partition_template)
+    out_partition = copy_partition(partition_template)
     out_partition.mean = model.mean
     out_partition.var = (model.volatility^2) / (2 * model.reversion)
     out_partition.norm_const = 0.0

--- a/src/models/discrete_models/discrete_partitions.jl
+++ b/src/models/discrete_models/discrete_partitions.jl
@@ -167,7 +167,7 @@ function eq_freq_from_template(
     model::DiscreteStateModel,
     partition_template::DiscretePartition,
 )
-    out_partition = deepcopy(partition_template)
+    out_partition = copy_partition(partition_template)
     eq_freq_vec = eq_freq(model) #This will dispatch correctly for existing models.
     out_partition.state .= repeat(eq_freq_vec, outer = [1, out_partition.sites])
     return out_partition
@@ -178,7 +178,7 @@ function equilibrium_message(
     model_vec::Vector{<:DiscreteStateModel},
     message_template::Vector{<:DiscretePartition},
 )
-    out_mess = deepcopy(message_template)
+    out_mess = copy_message(message_template)
     for part = 1:length(message_template)
         eq_freq_vec = eq_freq(model_vec[part])
         out_mess[part].state .= repeat(eq_freq_vec, outer = [1, out_mess[part].sites])

--- a/src/utils/misc.jl
+++ b/src/utils/misc.jl
@@ -86,7 +86,7 @@ function populate_tree!(
     if init_all_messages
         internal_message_init!(tree, starting_message)
     else
-        tree.parent_message = deepcopy(starting_message)
+        tree.parent_message = copy_message(starting_message)
     end
     name_dic = Dict(zip(names, 1:length(names)))
     for n in getleaflist(tree)

--- a/test/test_felsenstein.jl
+++ b/test/test_felsenstein.jl
@@ -9,14 +9,14 @@ begin
     newt.parent_message = equilibrium_message([m1], empty_mess)
     internal_message_init!(newt, empty_mess)
     for n in getnodelist(newt)
-        n.message = deepcopy(empty_mess)
+        n.message = copy_message(empty_mess)
     end
     for n in getnodelist(newt)
         n.message[1].state = [1.0 0.0; 0.0 0.0; 0.0 0.0; 0.0 1.0]
     end
     n = getleaflist(newt)[1]
     n.message[1].state = [0.0 1.0; 0.0 0.0; 0.0 0.0; 1.0 0.0]
-    null_mess = deepcopy(newt.message)
+    null_mess = copy_message(newt.message)
     newt.parent_message = equilibrium_message([m1], empty_mess)
     # TODO: The following code results in a method error.
     #felsenstein_up!(null_mess,newt,models,1:length(null_mess))


### PR DESCRIPTION
Follow up to PR #16 
--------------------
This PR accomplishes two things:
1. Replaces `deepcopy` with `copy_partition` and `copy_message` throughout the whole package
2. Implements `copy_partition` for `SWMPartition`

Example where we have replaced `deepcopy`:
```
tree = sim_tree(n = 100_000)
empty_message = [NucleotidePartition(30)]
@time MolecularEvolution.random_leaf_init!(tree, empty_message)

# main
 0.521992 seconds (6.95 M allocations: 379.846 MiB, 24.52% gc time, 9.05% compilation time)

# PR
 0.405800 seconds (6.73 M allocations: 346.599 MiB, 28.74% gc time, 11.90% compilation time)
```

Example with SWMPartition:
```
tree = sim_tree(n = 10_000)
@time internal_message_init!(tree, SWMPartition{CodonPartition}(CodonPartition(30), 2))

# main
 0.536884 seconds (800.27 k allocations: 1.737 GiB, 29.93% gc time, 1.52% compilation time)

# PR
 0.355919 seconds (679.98 k allocations: 1.718 GiB, 46.63% gc time)
```