### PR TITLE
Fix binarize! during newick import

### DIFF
--- a/src/core/nodes/AbstractTreeNode.jl
+++ b/src/core/nodes/AbstractTreeNode.jl
@@ -309,7 +309,7 @@ function gettreefromnewick(str, T::DataType; tagged = false, disable_binarize = 
             i += 1
         elseif c == ';'
             try_apply_char_arr(currnode, char_arr)
-            return (tagged ? (currnode, tag_dict) : currnode)
+            break
         else
             push!(char_arr, c)
             #println(char_arr)
@@ -317,7 +317,7 @@ function gettreefromnewick(str, T::DataType; tagged = false, disable_binarize = 
         end
     end
 
-    binarize!(currnode)
+    !disable_binarize && binarize!(currnode)
 
     return (tagged ? (currnode, tag_dict) : currnode)
 end

--- a/src/utils/misc.jl
+++ b/src/utils/misc.jl
@@ -261,10 +261,7 @@ function read_newick_tree(
     strip_single_quotes = true,
 )
     treestring = read(treefile, String)
-    tree = gettreefromnewick(treestring, FelNode)
-    if binarize
-        binarize!(tree)
-    end
+    tree = gettreefromnewick(treestring, FelNode, disable_binarize=!binarize)
     if ladderize
         ladderize!(tree)
     end


### PR DESCRIPTION
Properly control if we call `binarize!` in `gettreefromnewick` and `read_newick_tree`